### PR TITLE
Allow building for older cards by specifying CUDA_ARCH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,8 +50,7 @@ include_directories(${BZip2_INCLUDE_DIR})
 find_package(CUDA 2.3 REQUIRED)
 set (CUDA_ARCH  "sm_13" 
  CACHE STRING
-    "CUDA architecture."
-    FORCE )
+    "CUDA architecture.")
 MARK_AS_ADVANCED(CUDA_ARCH)
 
 set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -arch=${CUDA_ARCH})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,13 @@ include_directories(${BZip2_INCLUDE_DIR})
 
 ### CUDA
 find_package(CUDA 2.3 REQUIRED)
-set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -arch=sm_13)
+set (CUDA_ARCH  "sm_13" 
+ CACHE STRING
+    "CUDA architecture."
+    FORCE )
+MARK_AS_ADVANCED(CUDA_ARCH)
+
+set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -arch=${CUDA_ARCH})
 
 if( NOT "x${GCC_ROOT}" STREQUAL "x" )
 	set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} "-ccbin=${GCC_ROOT}/bin")

--- a/src/common/gpu.h
+++ b/src/common/gpu.h
@@ -15,6 +15,12 @@
 // Note: __CUDACC__ will never be defined when BUILD_FOR_CPU is defined
 //
 //////////////////////////////////////////////////////////////////////////
+#if __CUDA_ARCH__ > 120
+#define NVTYPE double
+#else
+#define NVTYPE float
+#endif 
+
 
 #include "cux.h"
 

--- a/src/skygen/skyconfig_impl.h
+++ b/src/skygen/skyconfig_impl.h
@@ -134,8 +134,8 @@ void skygenHost<T>::download(bool draw, int pixfrom, int pixto)
 	}
 	else
 	{
-		double *cpu_counts = new double[this->nthreads];
-		double *cpu_countsCovered = new double[this->nthreads];
+		NVTYPE *cpu_counts = new NVTYPE[this->nthreads];
+		NVTYPE *cpu_countsCovered = new NVTYPE[this->nthreads];
 		this->counts.download(cpu_counts, this->nthreads);
 		this->countsCovered.download(cpu_countsCovered, this->nthreads);
 		// sum up the total expected number of stars

--- a/src/skygen/skygen.h
+++ b/src/skygen/skygen.h
@@ -273,7 +273,7 @@ struct ALIGN(16) skygenGPU : public skygenParams
 	cuxDevicePtr<pencilBeam> pixels;	// pixels on the sky to process
 
 	cuxDevicePtr<int> nstars;
-	cuxDevicePtr<double> counts, countsCovered;
+	cuxDevicePtr<NVTYPE> counts, countsCovered;
 	gptr<float, 2> countsCoveredPerBeam;
 	ocolumns stars;
 

--- a/tests/demo/photometry.conf
+++ b/tests/demo/photometry.conf
@@ -3,7 +3,7 @@ module = photometry
 # Apply to components 0,1,2
 compFirst = 0
 compLast = 2
-
+comp= 0 1 2
 #
 # Define the photometric system
 #


### PR DESCRIPTION
Hi Mario,

I've made it possible to build galfast on older cards without double types.

Cheers,
         S
