### PR TITLE
Added program_options, system to required Boost Components after getting error when trying to 'make'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ find_package(GSL REQUIRED)
 include_directories(${GSL_INCLUDE_DIR})
 
 ### Boost
-find_package(Boost REQUIRED COMPONENTS regex iostreams thread system)
+find_package(Boost REQUIRED COMPONENTS regex iostreams thread program_options system)
 include_directories(${Boost_INCLUDE_DIRS})
 
 ### CFITSIO


### PR DESCRIPTION
I found the same error here that I encountered with libpeyton.
